### PR TITLE
bugfix: eslint is broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.15
+
+- Fixed ESLint by updating `eslint-plugin-import` to version 2.22.1 
+
 ## 5.1.14
 
 - Fix moment.js Spanish localization in the webpack configuration.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -49,7 +49,7 @@
     "eslint-config-react-app": "^5.2.0",
     "eslint-loader": "3.0.3",
     "eslint-plugin-flowtype": "4.6.0",
-    "eslint-plugin-import": "2.20.0",
+    "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jest": "^23.7.0",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-react": "7.18.0",


### PR DESCRIPTION
ESlint was broken. One if the ESLint dependencies - `eslint-config-airbnb-base` has the peer dependency `"eslint-plugin-import": "^2.22.1"`.
Without it eslint is broken 